### PR TITLE
TLS conn does not reconnect in tls but in tcp

### DIFF
--- a/gelf/tcpwriter.go
+++ b/gelf/tcpwriter.go
@@ -20,6 +20,10 @@ type TCPWriter struct {
 	ReconnectDelay time.Duration
 }
 
+func (w *TCPWriter) Dial(addr string) (net.Conn, error) {
+	return net.Dial("tcp", w.addr)
+}
+
 func NewTCPWriter(addr string) (*TCPWriter, error) {
 	var err error
 	w := new(TCPWriter)
@@ -28,7 +32,7 @@ func NewTCPWriter(addr string) (*TCPWriter, error) {
 	w.proto = "tcp"
 	w.addr = addr
 
-	if w.conn, err = net.Dial("tcp", addr); err != nil {
+	if w.conn, err = w.Dial(addr); err != nil {
 		return nil, err
 	}
 	if w.hostname, err = os.Hostname(); err != nil {
@@ -90,7 +94,7 @@ func (w *TCPWriter) writeToSocketWithReconnectAttempts(zBytes []byte) (n int, er
 		}
 		if err != nil {
 			time.Sleep(w.ReconnectDelay * time.Second)
-			w.conn, errConn = net.Dial("tcp", w.addr)
+			w.conn, errConn = w.Dial(w.addr)
 		} else {
 			break
 		}

--- a/gelf/tlswriter.go
+++ b/gelf/tlswriter.go
@@ -2,12 +2,17 @@ package gelf
 
 import (
 	"crypto/tls"
+	"net"
 	"os"
 )
 
 type TLSWriter struct {
 	TCPWriter
 	TlsConfig *tls.Config
+}
+
+func (w *TLSWriter) Dial(addr string) (net.Conn, error) {
+	return tls.Dial("tcp", addr, w.TlsConfig)
 }
 
 func NewTLSWriter(addr string, tlsConfig *tls.Config) (*TLSWriter, error) {
@@ -19,7 +24,7 @@ func NewTLSWriter(addr string, tlsConfig *tls.Config) (*TLSWriter, error) {
 	w.TlsConfig = tlsConfig
 
 	var err error
-	if w.conn, err = tls.Dial("tcp", addr, w.TlsConfig); err != nil {
+	if w.conn, err = w.Dial(w.addr); err != nil {
 		return nil, err
 	}
 	if w.hostname, err = os.Hostname(); err != nil {

--- a/gelf/udpwriter.go
+++ b/gelf/udpwriter.go
@@ -60,6 +60,10 @@ func numChunks(b []byte) int {
 	return len(b)/chunkedDataLen + 1
 }
 
+func (w *UDPWriter) Dial(addr string) (net.Conn, error) {
+	return net.Dial("udp", addr)
+}
+
 // New returns a new GELF Writer.  This writer can be used to send the
 // output of the standard Go log functions to a central GELF server by
 // passing it to log.SetOutput()
@@ -68,7 +72,7 @@ func NewUDPWriter(addr string) (*UDPWriter, error) {
 	w := new(UDPWriter)
 	w.CompressionLevel = flate.BestSpeed
 
-	if w.conn, err = net.Dial("udp", addr); err != nil {
+	if w.conn, err = w.Dial(addr); err != nil {
 		return nil, err
 	}
 	if w.hostname, err = os.Hostname(); err != nil {
@@ -84,8 +88,8 @@ func NewUDPWriter(addr string) (*UDPWriter, error) {
 // of GELF chunked messages.  The format is documented at
 // http://docs.graylog.org/en/2.1/pages/gelf.html as:
 //
-//     2-byte magic (0x1e 0x0f), 8 byte id, 1 byte sequence id, 1 byte
-//     total, chunk-data
+//	2-byte magic (0x1e 0x0f), 8 byte id, 1 byte sequence id, 1 byte
+//	total, chunk-data
 func (w *GelfWriter) writeChunked(zBytes []byte) (err error) {
 	b := make([]byte, 0, ChunkSize)
 	buf := bytes.NewBuffer(b)

--- a/gelf/writer.go
+++ b/gelf/writer.go
@@ -12,6 +12,7 @@ type Writer interface {
 	Close() error
 	Write([]byte) (int, error)
 	WriteMessage(*Message) error
+	Dial(string) (net.Conn, error)
 }
 
 // Writer implements io.Writer and is used to send both discrete


### PR DESCRIPTION
TLS reconnect mechanism is broken as TLSWritter use the TCPWritr.writeToSocketWithReconnectAttempts.

So the reconnect is done in pure TCP without TLS and the GELF connection get lost after some times.

To solve this, i added a Dial method to the Writer interface that allow abstraction of the dial method for each writer protocol and allow the reuse of the tlsconfig parameter at re-connection attempts.